### PR TITLE
feat: MCP settings and Streamable HTTP bill tools

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -8,6 +8,7 @@ from .messages import router as messages_router
 from .users import router as users_router
 from .system_config import router as system_config_router
 from .classification_rules import router as classification_rules_router
+from .mcp_settings import router as mcp_settings_router
 
 api_router = APIRouter(prefix="/api/v1")
 api_router.include_router(auth_router)
@@ -19,5 +20,6 @@ api_router.include_router(messages_router)
 api_router.include_router(users_router)
 api_router.include_router(system_config_router)
 api_router.include_router(classification_rules_router)
+api_router.include_router(mcp_settings_router)
 
 __all__ = ["api_router"]

--- a/backend/api/mcp_settings.py
+++ b/backend/api/mcp_settings.py
@@ -1,0 +1,160 @@
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.orm import Session
+
+from api.auth import get_current_user
+from bill_mcp.context import current_mcp_user
+from bill_mcp.server import mcp
+from config.database import SessionLocal, get_db
+from config.settings import settings
+from models.user import User
+from schemas.common import ApiResponse
+from schemas.mcp import McpApiKeyCreateResponse, McpApiKeyResponse, McpServerInfoResponse
+from services.mcp_api_key_service import (
+    authenticate_mcp_api_key,
+    create_mcp_api_key,
+    get_active_mcp_api_key,
+    revoke_mcp_api_key,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/mcp", tags=["mcp"])
+
+_mcp_asgi_handler = None
+
+
+def _extract_api_key(request: Request) -> Optional[str]:
+    auth_header = request.headers.get("authorization", "")
+    if auth_header.lower().startswith("bearer "):
+        return auth_header[7:].strip()
+    return request.headers.get("x-mcp-api-key")
+
+
+def _authenticate_request(request: Request) -> User:
+    raw_key = _extract_api_key(request)
+    if not raw_key:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="缺少 MCP API Key")
+
+    db = SessionLocal()
+    try:
+        user = authenticate_mcp_api_key(db, raw_key)
+        if not user:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="无效的 MCP API Key")
+        return user
+    finally:
+        db.close()
+
+
+def _get_mcp_asgi_handler():
+    global _mcp_asgi_handler
+    if _mcp_asgi_handler is None:
+        starlette_app = mcp.streamable_http_app()
+        for route in starlette_app.routes:
+            if getattr(route, "path", None) == mcp.settings.streamable_http_path:
+                _mcp_asgi_handler = route.endpoint
+                break
+        if _mcp_asgi_handler is None:
+            raise RuntimeError("MCP Streamable HTTP handler not found")
+    return _mcp_asgi_handler
+
+
+async def handle_mcp_transport(request: Request):
+    """Streamable HTTP MCP 端点（标准路径 /mcp）。"""
+    user = _authenticate_request(request)
+    token = current_mcp_user.set(user)
+    try:
+        handler = _get_mcp_asgi_handler()
+        await handler(request.scope, request.receive, request._send)
+    finally:
+        current_mcp_user.reset(token)
+
+
+def register_mcp_transport(app) -> None:
+    app.add_api_route(
+        "/mcp",
+        handle_mcp_transport,
+        methods=["GET", "POST", "DELETE"],
+        include_in_schema=False,
+    )
+
+
+def _build_mcp_url(request: Optional[Request] = None) -> str:
+    if request is not None:
+        base = str(request.base_url).rstrip("/")
+        return f"{base}/mcp"
+    host = settings.HOST if settings.HOST not in ("0.0.0.0", "::") else "localhost"
+    return f"http://{host}:{settings.PORT}/mcp"
+
+
+@router.get("/settings", response_model=ApiResponse[McpApiKeyResponse])
+async def get_mcp_settings(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    record = get_active_mcp_api_key(db, current_user.id)
+    if not record:
+        return ApiResponse(data=McpApiKeyResponse(has_key=False))
+    return ApiResponse(
+        data=McpApiKeyResponse(
+            has_key=True,
+            key_prefix=record.key_prefix,
+            name=record.name,
+            created_at=record.created_at,
+            last_used_at=record.last_used_at,
+        )
+    )
+
+
+@router.post("/settings/api-key", response_model=ApiResponse[McpApiKeyCreateResponse])
+async def generate_mcp_api_key(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    record, raw_key = create_mcp_api_key(db, current_user)
+    return ApiResponse(
+        data=McpApiKeyCreateResponse(
+            api_key=raw_key,
+            key_prefix=record.key_prefix,
+            created_at=record.created_at,
+        ),
+        message="MCP API Key 已生成，请妥善保存，仅显示一次",
+    )
+
+
+@router.delete("/settings/api-key", response_model=ApiResponse)
+async def delete_mcp_api_key(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    revoked = revoke_mcp_api_key(db, current_user.id)
+    if not revoked:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="当前没有可用的 MCP API Key")
+    return ApiResponse(message="MCP API Key 已撤销")
+
+
+@router.get("/info", response_model=ApiResponse[McpServerInfoResponse])
+async def get_mcp_server_info(
+    request: Request,
+    current_user: User = Depends(get_current_user),
+):
+    mcp_url = _build_mcp_url(request)
+    return ApiResponse(
+        data=McpServerInfoResponse(
+            server_name="Family Bills MCP",
+            mcp_url=mcp_url,
+            tools=["create_bill", "create_bills_batch", "query_bills_batch"],
+            cursor_config_example={
+                "mcpServers": {
+                    "family-bills": {
+                        "url": mcp_url,
+                        "headers": {
+                            "Authorization": "Bearer YOUR_MCP_API_KEY",
+                        },
+                    }
+                }
+            },
+        )
+    )

--- a/backend/bill_mcp/context.py
+++ b/backend/bill_mcp/context.py
@@ -1,0 +1,13 @@
+from contextvars import ContextVar
+from typing import Optional
+
+from models.user import User
+
+current_mcp_user: ContextVar[Optional[User]] = ContextVar("current_mcp_user", default=None)
+
+
+def get_current_mcp_user() -> User:
+    user = current_mcp_user.get()
+    if user is None:
+        raise RuntimeError("MCP 用户上下文未设置")
+    return user

--- a/backend/bill_mcp/server.py
+++ b/backend/bill_mcp/server.py
@@ -1,0 +1,172 @@
+import json
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from config.database import SessionLocal
+from bill_mcp.context import get_current_mcp_user
+from schemas.bills import BillCreate
+from services.bill_service import create_bill_record, create_bills_batch, query_bills
+
+logger = logging.getLogger(__name__)
+
+mcp = FastMCP("Family Bills MCP", stateless_http=True)
+
+
+def _parse_datetime(value: str) -> datetime:
+    for fmt in ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    raise ValueError(f"无法解析时间: {value}")
+
+
+def _build_bill_create(data: Dict[str, Any]) -> BillCreate:
+    transaction_time = data.get("transaction_time")
+    if isinstance(transaction_time, str):
+        transaction_time = _parse_datetime(transaction_time)
+
+    return BillCreate(
+        amount=float(data["amount"]),
+        transaction_type=data.get("transaction_type", "expense"),
+        transaction_time=transaction_time,
+        source_type=data.get("source_type", "manual"),
+        transaction_desc=data.get("transaction_desc") or data.get("description"),
+        remark=data.get("remark") or data.get("notes"),
+        category_id=data.get("category_id"),
+        raw_data=data.get("raw_data"),
+    )
+
+
+@mcp.tool()
+def create_bill(
+    amount: float,
+    transaction_time: str,
+    transaction_type: str = "expense",
+    transaction_desc: Optional[str] = None,
+    category_id: Optional[int] = None,
+    remark: Optional[str] = None,
+    source_type: str = "manual",
+) -> str:
+    """录入单条家庭账单。
+
+    Args:
+        amount: 金额（正数）
+        transaction_time: 交易时间，支持 YYYY-MM-DD 或 YYYY-MM-DD HH:MM:SS
+        transaction_type: 交易类型 income/expense/transfer
+        transaction_desc: 交易描述
+        category_id: 分类 ID（可选）
+        remark: 备注（可选）
+        source_type: 来源类型，默认 manual
+    """
+    user = get_current_mcp_user()
+    db = SessionLocal()
+    try:
+        payload = _build_bill_create(
+            {
+                "amount": amount,
+                "transaction_time": transaction_time,
+                "transaction_type": transaction_type,
+                "transaction_desc": transaction_desc,
+                "category_id": category_id,
+                "remark": remark,
+                "source_type": source_type,
+            }
+        )
+        bill = create_bill_record(db, user.id, payload)
+        return json.dumps(
+            {"success": True, "message": "创建账单成功", "bill": {"id": bill.id, "amount": bill.amount}},
+            ensure_ascii=False,
+        )
+    except Exception as exc:
+        logger.error("MCP create_bill failed: %s", exc)
+        return json.dumps({"success": False, "message": str(exc)}, ensure_ascii=False)
+    finally:
+        db.close()
+
+
+@mcp.tool()
+def create_bills_batch(bills: List[Dict[str, Any]]) -> str:
+    """批量录入家庭账单。
+
+    Args:
+        bills: 账单列表，每项包含 amount、transaction_time、transaction_type 等字段
+    """
+    user = get_current_mcp_user()
+    db = SessionLocal()
+    try:
+        payloads = [_build_bill_create(item) for item in bills]
+        created = create_bills_batch(db, user.id, payloads)
+        return json.dumps(
+            {
+                "success": True,
+                "message": f"成功创建 {len(created)} 条账单",
+                "created_count": len(created),
+                "bill_ids": [bill.id for bill in created],
+            },
+            ensure_ascii=False,
+        )
+    except Exception as exc:
+        logger.error("MCP create_bills_batch failed: %s", exc)
+        return json.dumps({"success": False, "message": str(exc)}, ensure_ascii=False)
+    finally:
+        db.close()
+
+
+@mcp.tool()
+def query_bills_batch(
+    page: int = 1,
+    size: int = 20,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    transaction_types: Optional[List[str]] = None,
+    category_ids: Optional[List[int]] = None,
+    user_ids: Optional[List[int]] = None,
+    search: Optional[str] = None,
+    min_amount: Optional[float] = None,
+    max_amount: Optional[float] = None,
+) -> str:
+    """批量查询家庭账单，支持多条件筛选。
+
+    Args:
+        page: 页码，从 1 开始
+        size: 每页条数，最大 100
+        start_date: 开始日期 YYYY-MM-DD
+        end_date: 结束日期 YYYY-MM-DD
+        transaction_types: 交易类型列表 income/expense/transfer
+        category_ids: 分类 ID 列表
+        user_ids: 家庭成员用户 ID 列表
+        search: 描述关键词
+        min_amount: 最小金额
+        max_amount: 最大金额
+    """
+    user = get_current_mcp_user()
+    db = SessionLocal()
+    try:
+        from datetime import date as date_type
+
+        parsed_start = date_type.fromisoformat(start_date) if start_date else None
+        parsed_end = date_type.fromisoformat(end_date) if end_date else None
+        result = query_bills(
+            db,
+            user.id,
+            page=max(page, 1),
+            size=min(max(size, 1), 100),
+            start_date=parsed_start,
+            end_date=parsed_end,
+            transaction_types=transaction_types,
+            category_ids=category_ids,
+            user_ids=user_ids,
+            search=search,
+            min_amount=min_amount,
+            max_amount=max_amount,
+        )
+        return json.dumps({"success": True, "data": result}, ensure_ascii=False, default=str)
+    except Exception as exc:
+        logger.error("MCP query_bills_batch failed: %s", exc)
+        return json.dumps({"success": False, "message": str(exc)}, ensure_ascii=False)
+    finally:
+        db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,8 @@ from config.logging import init_logging, get_logger
 
 # 导入路由
 from api import api_router
+from api.mcp_settings import register_mcp_transport
+from bill_mcp.server import mcp
 
 # 导入异常处理和中间件
 from core.exceptions import setup_exception_handlers
@@ -40,8 +42,11 @@ async def lifespan(app: FastAPI):
     # 确保必要目录存在
     settings.upload_path.mkdir(parents=True, exist_ok=True)
     settings.log_path.parent.mkdir(parents=True, exist_ok=True)
-    
-    yield
+
+    # 启动 MCP Streamable HTTP session manager
+    mcp.streamable_http_app()
+    async with mcp.session_manager.run():
+        yield
     
     # 关闭时清理
     logger.info("应用关闭")
@@ -83,6 +88,9 @@ if settings.is_production:
 
 # 注册路由
 app.include_router(api_router)
+
+# MCP Streamable HTTP 传输（标准路径 /mcp）
+register_mcp_transport(app)
 
 
 @app.get("/", response_model=ApiResponse)

--- a/backend/migrations/add_mcp_api_keys.sql
+++ b/backend/migrations/add_mcp_api_keys.sql
@@ -1,0 +1,15 @@
+-- MCP API Key 表
+CREATE TABLE IF NOT EXISTS mcp_api_keys (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    key_hash VARCHAR(64) NOT NULL UNIQUE,
+    key_prefix VARCHAR(12) NOT NULL,
+    name VARCHAR(100) DEFAULT 'default',
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    last_used_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_api_keys_user_id ON mcp_api_keys(user_id);
+CREATE INDEX IF NOT EXISTS idx_mcp_api_keys_key_hash ON mcp_api_keys(key_hash);

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -4,6 +4,7 @@ from .bill import Bill, BillCategory
 from .message import Message, MessageAction
 from .system_config import SystemConfig
 from .classification_rule import ClassificationRule
+from .mcp_api_key import McpApiKey
 
 __all__ = [
     "User",
@@ -15,4 +16,5 @@ __all__ = [
     "MessageAction",
     "SystemConfig",
     "ClassificationRule",
+    "McpApiKey",
 ]

--- a/backend/models/mcp_api_key.py
+++ b/backend/models/mcp_api_key.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+from config.database import Base
+
+
+class McpApiKey(Base):
+    """用户 MCP API Key，用于外部 MCP 客户端认证"""
+
+    __tablename__ = "mcp_api_keys"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    key_hash = Column(String(64), nullable=False, unique=True, index=True)
+    key_prefix = Column(String(12), nullable=False, comment="Key 前缀，用于展示")
+    name = Column(String(100), nullable=True, default="default")
+    is_active = Column(Boolean, default=True, nullable=False)
+    last_used_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    user = relationship("User", backref="mcp_api_keys")
+
+    def __repr__(self):
+        return f"<McpApiKey(id={self.id}, user_id={self.user_id}, prefix={self.key_prefix})>"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 # 核心框架
-fastapi==0.104.1
-uvicorn[standard]==0.24.0
+fastapi>=0.115.0
+uvicorn[standard]>=0.30.0
 
 # 数据库相关
 sqlalchemy==2.0.23
@@ -38,3 +38,6 @@ asyncpg==0.29.0
 
 # AI模型
 zai-sdk
+
+# MCP Server (Streamable HTTP)
+mcp>=1.10.0

--- a/backend/schemas/mcp.py
+++ b/backend/schemas/mcp.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class McpApiKeyResponse(BaseModel):
+    has_key: bool
+    key_prefix: Optional[str] = None
+    name: Optional[str] = None
+    created_at: Optional[datetime] = None
+    last_used_at: Optional[datetime] = None
+
+
+class McpApiKeyCreateResponse(BaseModel):
+    api_key: str = Field(..., description="明文 API Key，仅创建时返回一次")
+    key_prefix: str
+    created_at: datetime
+
+
+class McpServerInfoResponse(BaseModel):
+    server_name: str
+    mcp_url: str
+    tools: List[str]
+    cursor_config_example: dict

--- a/backend/services/bill_service.py
+++ b/backend/services/bill_service.py
@@ -1,0 +1,150 @@
+from datetime import date, datetime
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.orm import Session, joinedload
+from sqlalchemy import desc
+
+from models.bill import Bill, BillCategory
+from models.family import FamilyMember
+from schemas.bills import BillCreate, BillResponse
+
+
+TRANSACTION_TYPE_TO_CN = {
+    "income": "收入",
+    "expense": "支出",
+    "transfer": "不计收支",
+}
+
+
+def get_user_family_member_ids(db: Session, user_id: int) -> List[int]:
+    family_member = db.query(FamilyMember).filter(FamilyMember.user_id == user_id).first()
+    if not family_member:
+        return [user_id]
+
+    members = db.query(FamilyMember).filter(FamilyMember.family_id == family_member.family_id).all()
+    return [member.user_id for member in members]
+
+
+def _validate_category(db: Session, category_id: Optional[int]) -> None:
+    if category_id is None:
+        return
+    valid = (
+        db.query(BillCategory)
+        .filter(BillCategory.id == category_id, BillCategory.is_deleted == False)
+        .first()
+    )
+    if not valid:
+        raise ValueError("分类不存在或已删除")
+
+
+def create_bill_record(db: Session, user_id: int, payload: BillCreate) -> Bill:
+    _validate_category(db, payload.category_id)
+
+    transaction_type_cn = TRANSACTION_TYPE_TO_CN.get(payload.transaction_type, payload.transaction_type)
+    bill = Bill(
+        user_id=user_id,
+        category_id=payload.category_id,
+        transaction_time=payload.transaction_time,
+        amount=payload.amount,
+        transaction_type=transaction_type_cn,
+        transaction_desc=payload.transaction_desc or payload.description,
+        source_type=payload.source_type,
+        remark=payload.remark or payload.notes,
+        raw_data=payload.raw_data,
+    )
+    db.add(bill)
+    db.commit()
+    db.refresh(bill)
+    return bill
+
+
+def create_bills_batch(db: Session, user_id: int, bills: List[BillCreate]) -> List[Bill]:
+    created: List[Bill] = []
+    try:
+        for payload in bills:
+            _validate_category(db, payload.category_id)
+            transaction_type_cn = TRANSACTION_TYPE_TO_CN.get(payload.transaction_type, payload.transaction_type)
+            bill = Bill(
+                user_id=user_id,
+                category_id=payload.category_id,
+                transaction_time=payload.transaction_time,
+                amount=payload.amount,
+                transaction_type=transaction_type_cn,
+                transaction_desc=payload.transaction_desc or payload.description,
+                source_type=payload.source_type,
+                remark=payload.remark or payload.notes,
+                raw_data=payload.raw_data,
+            )
+            db.add(bill)
+            created.append(bill)
+        db.commit()
+        for bill in created:
+            db.refresh(bill)
+        return created
+    except Exception:
+        db.rollback()
+        raise
+
+
+def query_bills(
+    db: Session,
+    user_id: int,
+    *,
+    page: int = 1,
+    size: int = 20,
+    start_date: Optional[date] = None,
+    end_date: Optional[date] = None,
+    transaction_types: Optional[List[str]] = None,
+    category_ids: Optional[List[int]] = None,
+    user_ids: Optional[List[int]] = None,
+    search: Optional[str] = None,
+    min_amount: Optional[float] = None,
+    max_amount: Optional[float] = None,
+) -> Dict[str, Any]:
+    family_user_ids = get_user_family_member_ids(db, user_id)
+    query = (
+        db.query(Bill)
+        .options(joinedload(Bill.category), joinedload(Bill.user))
+        .filter(Bill.user_id.in_(family_user_ids))
+    )
+
+    if user_ids:
+        selected = [uid for uid in user_ids if uid in family_user_ids]
+        if selected:
+            query = query.filter(Bill.user_id.in_(selected))
+
+    if category_ids:
+        query = query.filter(Bill.category_id.in_(category_ids))
+
+    if transaction_types:
+        cn_types = [TRANSACTION_TYPE_TO_CN.get(t, t) for t in transaction_types]
+        query = query.filter(Bill.transaction_type.in_(cn_types))
+
+    if start_date:
+        query = query.filter(Bill.transaction_time >= datetime.combine(start_date, datetime.min.time()))
+    if end_date:
+        query = query.filter(Bill.transaction_time <= datetime.combine(end_date, datetime.max.time()))
+
+    if min_amount is not None:
+        query = query.filter(Bill.amount >= min_amount)
+    if max_amount is not None:
+        query = query.filter(Bill.amount <= max_amount)
+
+    if search:
+        like = f"%{search}%"
+        query = query.filter(Bill.transaction_desc.ilike(like))
+
+    total = query.count()
+    items = (
+        query.order_by(desc(Bill.transaction_time))
+        .offset((page - 1) * size)
+        .limit(size)
+        .all()
+    )
+
+    return {
+        "total": total,
+        "page": page,
+        "size": size,
+        "items": [BillResponse.from_bill(bill).model_dump(mode="json") for bill in items],
+    }

--- a/backend/services/mcp_api_key_service.py
+++ b/backend/services/mcp_api_key_service.py
@@ -1,0 +1,81 @@
+import hashlib
+import secrets
+from datetime import datetime, timezone
+from typing import Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from models.mcp_api_key import McpApiKey
+from models.user import User
+
+MCP_KEY_PREFIX = "mcp_"
+
+
+def hash_mcp_api_key(raw_key: str) -> str:
+    return hashlib.sha256(raw_key.encode("utf-8")).hexdigest()
+
+
+def generate_mcp_api_key() -> str:
+    return f"{MCP_KEY_PREFIX}{secrets.token_urlsafe(32)}"
+
+
+def create_mcp_api_key(db: Session, user: User, name: str = "default") -> Tuple[McpApiKey, str]:
+    """生成新的 MCP API Key，返回 (记录, 明文 key)。同一用户仅保留一个 active key。"""
+    db.query(McpApiKey).filter(
+        McpApiKey.user_id == user.id,
+        McpApiKey.is_active == True,
+    ).update({"is_active": False})
+
+    raw_key = generate_mcp_api_key()
+    record = McpApiKey(
+        user_id=user.id,
+        key_hash=hash_mcp_api_key(raw_key),
+        key_prefix=raw_key[:12],
+        name=name,
+        is_active=True,
+    )
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+    return record, raw_key
+
+
+def get_active_mcp_api_key(db: Session, user_id: int) -> Optional[McpApiKey]:
+    return (
+        db.query(McpApiKey)
+        .filter(McpApiKey.user_id == user_id, McpApiKey.is_active == True)
+        .order_by(McpApiKey.created_at.desc())
+        .first()
+    )
+
+
+def revoke_mcp_api_key(db: Session, user_id: int) -> bool:
+    updated = (
+        db.query(McpApiKey)
+        .filter(McpApiKey.user_id == user_id, McpApiKey.is_active == True)
+        .update({"is_active": False})
+    )
+    db.commit()
+    return updated > 0
+
+
+def authenticate_mcp_api_key(db: Session, raw_key: str) -> Optional[User]:
+    if not raw_key or not raw_key.startswith(MCP_KEY_PREFIX):
+        return None
+
+    key_hash = hash_mcp_api_key(raw_key)
+    record = (
+        db.query(McpApiKey)
+        .filter(McpApiKey.key_hash == key_hash, McpApiKey.is_active == True)
+        .first()
+    )
+    if not record:
+        return None
+
+    user = db.query(User).filter(User.id == record.user_id, User.is_active == True).first()
+    if not user:
+        return None
+
+    record.last_used_at = datetime.now(timezone.utc)
+    db.commit()
+    return user

--- a/family-bills-https.conf
+++ b/family-bills-https.conf
@@ -38,6 +38,21 @@ server {
         # 客户端请求体大小限制
         client_max_body_size 100M;
     }
+
+    # MCP Streamable HTTP 代理到后端
+    location = /mcp {
+        proxy_pass http://localhost:8000/mcp;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection '';
+        proxy_buffering off;
+        proxy_cache off;
+        chunked_transfer_encoding off;
+        proxy_read_timeout 86400s;
+    }
     
     # 静态资源缓存
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import FamilyManagePage from './pages/FamilyManagePage';
 import UsersManagePage from './pages/UsersManagePage';
 import ClassificationRulesPage from './pages/ClassificationRulesPage';
 import PersonalCenterPage from './pages/PersonalCenterPage';
+import McpSettingsPage from './pages/McpSettingsPage';
 import './App.css';
 
 // 受保护的路由组件
@@ -116,6 +117,7 @@ const App: React.FC = () => {
               <Route path="family" element={<FamilyManagePage />} />
               <Route path="classification-rules" element={<ClassificationRulesPage />} />
               <Route path="settings" element={<SettingsPage />} />
+              <Route path="mcp-settings" element={<McpSettingsPage />} />
               <Route path="profile" element={<PersonalCenterPage />} />
               <Route path="*" element={<Navigate to="/dashboard" replace />} />
             </Route>

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -97,4 +97,11 @@ export const API_ENDPOINTS = {
     BY_ID: (id: number) => `/api/v1/messages/${id}`,
     ACTION: (id: number) => `/api/v1/messages/${id}/actions`,
   },
+
+  // MCP 相关
+  MCP: {
+    SETTINGS: '/api/v1/mcp/settings',
+    API_KEY: '/api/v1/mcp/settings/api-key',
+    INFO: '/api/v1/mcp/info',
+  },
 }

--- a/frontend/src/api/services.ts
+++ b/frontend/src/api/services.ts
@@ -28,6 +28,11 @@ import type {
 } from '../types';
 import type { MonthlyExpenseTrendResponse } from '../types/bills';
 import type {
+  McpApiKeyCreateResult,
+  McpApiKeyStatus,
+  McpServerInfo,
+} from '../types/mcp';
+import type {
   MessageListResponse,
   MessageUpdate,
   MessageActionCreate,
@@ -418,6 +423,24 @@ export const ClassificationRuleService = {
   },
 };
 
+export const McpService = {
+  async getSettings(): Promise<ApiResponse<McpApiKeyStatus>> {
+    return ApiClient.get<McpApiKeyStatus>(API_ENDPOINTS.MCP.SETTINGS);
+  },
+
+  async generateApiKey(): Promise<ApiResponse<McpApiKeyCreateResult>> {
+    return ApiClient.post<McpApiKeyCreateResult>(API_ENDPOINTS.MCP.API_KEY);
+  },
+
+  async revokeApiKey(): Promise<ApiResponse<null>> {
+    return ApiClient.delete<null>(API_ENDPOINTS.MCP.API_KEY);
+  },
+
+  async getServerInfo(): Promise<ApiResponse<McpServerInfo>> {
+    return ApiClient.get<McpServerInfo>(API_ENDPOINTS.MCP.INFO);
+  },
+};
+
 export default {
   AuthService,
   UserService,
@@ -427,4 +450,5 @@ export default {
   SystemConfigService,
   MessageService,
   ClassificationRuleService,
+  McpService,
 };

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -21,6 +21,7 @@ import {
   MessageOutlined,
   TeamOutlined,
   FilterOutlined,
+  ApiOutlined,
 } from '@ant-design/icons';
 import { useAuthStore } from '../stores/auth';
 import type { MenuProps } from 'antd';
@@ -94,6 +95,11 @@ const Layout: React.FC = () => {
       key: '/profile',
       icon: <UserOutlined />,
       label: '个人资料',
+    },
+    {
+      key: '/mcp-settings',
+      icon: <ApiOutlined />,
+      label: 'MCP 设置',
     },
   ];
 

--- a/frontend/src/pages/McpSettingsPage.tsx
+++ b/frontend/src/pages/McpSettingsPage.tsx
@@ -1,0 +1,229 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Card,
+  Descriptions,
+  Input,
+  Modal,
+  Space,
+  Tag,
+  Typography,
+  message,
+  Divider,
+  List,
+} from 'antd';
+import {
+  ApiOutlined,
+  CopyOutlined,
+  KeyOutlined,
+  ReloadOutlined,
+  DeleteOutlined,
+} from '@ant-design/icons';
+import { McpService } from '../api/services';
+import type { McpApiKeyStatus, McpServerInfo } from '../types/mcp';
+
+const { Paragraph, Text, Title } = Typography;
+
+const McpSettingsPage: React.FC = () => {
+  const [loading, setLoading] = useState(false);
+  const [keyStatus, setKeyStatus] = useState<McpApiKeyStatus | null>(null);
+  const [serverInfo, setServerInfo] = useState<McpServerInfo | null>(null);
+  const [newApiKey, setNewApiKey] = useState<string | null>(null);
+  const [showKeyModal, setShowKeyModal] = useState(false);
+
+  const loadData = async () => {
+    try {
+      setLoading(true);
+      const [settingsRes, infoRes] = await Promise.all([
+        McpService.getSettings(),
+        McpService.getServerInfo(),
+      ]);
+      setKeyStatus(settingsRes.data);
+      setServerInfo(infoRes.data);
+    } catch {
+      message.error('加载 MCP 设置失败');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  const handleGenerateKey = async () => {
+    try {
+      setLoading(true);
+      const res = await McpService.generateApiKey();
+      setNewApiKey(res.data.api_key);
+      setShowKeyModal(true);
+      await loadData();
+      message.success('MCP API Key 已生成');
+    } catch (error: any) {
+      message.error(error.response?.data?.detail || '生成 API Key 失败');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRevokeKey = async () => {
+    Modal.confirm({
+      title: '确认撤销 MCP API Key？',
+      content: '撤销后，所有使用该 Key 的 MCP 客户端将无法连接。',
+      okText: '撤销',
+      okType: 'danger',
+      cancelText: '取消',
+      onOk: async () => {
+        try {
+          setLoading(true);
+          await McpService.revokeApiKey();
+          setNewApiKey(null);
+          await loadData();
+          message.success('MCP API Key 已撤销');
+        } catch (error: any) {
+          message.error(error.response?.data?.detail || '撤销失败');
+        } finally {
+          setLoading(false);
+        }
+      },
+    });
+  };
+
+  const copyText = async (text: string, label: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      message.success(`${label}已复制`);
+    } catch {
+      message.error('复制失败');
+    }
+  };
+
+  const cursorConfigText = serverInfo
+    ? JSON.stringify(serverInfo.cursor_config_example, null, 2)
+    : '';
+
+  return (
+    <div>
+      <Title level={4} style={{ marginBottom: 16 }}>
+        <ApiOutlined /> MCP 设置
+      </Title>
+
+      <Card title="API Key 管理" loading={loading} style={{ marginBottom: 16 }}>
+        {keyStatus?.has_key ? (
+          <>
+            <Descriptions column={1} bordered size="small">
+              <Descriptions.Item label="Key 前缀">
+                <Text code>{keyStatus.key_prefix}...</Text>
+              </Descriptions.Item>
+              <Descriptions.Item label="名称">{keyStatus.name || 'default'}</Descriptions.Item>
+              <Descriptions.Item label="创建时间">{keyStatus.created_at || '-'}</Descriptions.Item>
+              <Descriptions.Item label="最近使用">{keyStatus.last_used_at || '尚未使用'}</Descriptions.Item>
+            </Descriptions>
+            <Space style={{ marginTop: 16 }}>
+              <Button type="primary" icon={<ReloadOutlined />} onClick={handleGenerateKey} loading={loading}>
+                重新生成
+              </Button>
+              <Button danger icon={<DeleteOutlined />} onClick={handleRevokeKey} loading={loading}>
+                撤销 Key
+              </Button>
+            </Space>
+          </>
+        ) : (
+          <>
+            <Alert
+              type="warning"
+              showIcon
+              message="尚未配置 MCP API Key"
+              description="生成 API Key 后，可在 Cursor 等 MCP 客户端中连接家庭账单服务。"
+              style={{ marginBottom: 16 }}
+            />
+            <Button type="primary" icon={<KeyOutlined />} onClick={handleGenerateKey} loading={loading}>
+              生成 API Key
+            </Button>
+          </>
+        )}
+      </Card>
+
+      <Card title="MCP Server 信息" loading={loading} style={{ marginBottom: 16 }}>
+        {serverInfo && (
+          <>
+            <Descriptions column={1} bordered size="small">
+              <Descriptions.Item label="服务名称">{serverInfo.server_name}</Descriptions.Item>
+              <Descriptions.Item label="MCP 地址">
+                <Space>
+                  <Text code>{serverInfo.mcp_url}</Text>
+                  <Button
+                    size="small"
+                    icon={<CopyOutlined />}
+                    onClick={() => copyText(serverInfo.mcp_url, 'MCP 地址')}
+                  />
+                </Space>
+              </Descriptions.Item>
+            </Descriptions>
+
+            <Divider orientation="left">可用工具</Divider>
+            <List
+              size="small"
+              bordered
+              dataSource={[
+                { name: 'create_bill', desc: '单条账单录入' },
+                { name: 'create_bills_batch', desc: '批量账单录入' },
+                { name: 'query_bills_batch', desc: '批量账单查询（支持多条件筛选）' },
+              ]}
+              renderItem={(item) => (
+                <List.Item>
+                  <Space>
+                    <Tag color="blue">{item.name}</Tag>
+                    <Text>{item.desc}</Text>
+                  </Space>
+                </List.Item>
+              )}
+            />
+          </>
+        )}
+      </Card>
+
+      <Card title="Cursor 配置示例">
+        <Paragraph type="secondary">
+          在 Cursor 的 MCP 配置中添加以下内容（将 YOUR_MCP_API_KEY 替换为生成的 Key）：
+        </Paragraph>
+        <Input.TextArea
+          value={cursorConfigText}
+          readOnly
+          autoSize={{ minRows: 8, maxRows: 16 }}
+          style={{ fontFamily: 'monospace', marginBottom: 12 }}
+        />
+        <Button icon={<CopyOutlined />} onClick={() => copyText(cursorConfigText, '配置示例')}>
+          复制配置
+        </Button>
+      </Card>
+
+      <Modal
+        title="请保存 MCP API Key"
+        open={showKeyModal}
+        onCancel={() => setShowKeyModal(false)}
+        footer={[
+          <Button key="copy" type="primary" icon={<CopyOutlined />} onClick={() => newApiKey && copyText(newApiKey, 'API Key')}>
+            复制 Key
+          </Button>,
+          <Button key="close" onClick={() => setShowKeyModal(false)}>
+            我已保存
+          </Button>,
+        ]}
+        closable={false}
+        maskClosable={false}
+      >
+        <Alert
+          type="error"
+          showIcon
+          message="此 Key 仅显示一次，关闭后将无法再次查看"
+          style={{ marginBottom: 12 }}
+        />
+        <Input.TextArea value={newApiKey || ''} readOnly autoSize={{ minRows: 3 }} style={{ fontFamily: 'monospace' }} />
+      </Modal>
+    </div>
+  );
+};
+
+export default McpSettingsPage;

--- a/frontend/src/types/mcp.ts
+++ b/frontend/src/types/mcp.ts
@@ -1,0 +1,20 @@
+export interface McpApiKeyStatus {
+  has_key: boolean;
+  key_prefix?: string;
+  name?: string;
+  created_at?: string;
+  last_used_at?: string;
+}
+
+export interface McpApiKeyCreateResult {
+  api_key: string;
+  key_prefix: string;
+  created_at: string;
+}
+
+export interface McpServerInfo {
+  server_name: string;
+  mcp_url: string;
+  tools: string[];
+  cursor_config_example: Record<string, unknown>;
+}

--- a/ssl-certs/family-bills.conf
+++ b/ssl-certs/family-bills.conf
@@ -29,6 +29,21 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+
+    # MCP Streamable HTTP 代理到后端
+    location = /mcp {
+        proxy_pass http://127.0.0.1:8000/mcp;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection '';
+        proxy_buffering off;
+        proxy_cache off;
+        chunked_transfer_encoding off;
+        proxy_read_timeout 86400s;
+    }
     
     # 静态资源缓存
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {


### PR DESCRIPTION
## Summary
- Add MCP settings page for API key management and Cursor configuration
- Expose Streamable HTTP MCP endpoint at `/mcp` with API key authentication
- Provide three MCP tools: single bill entry, batch bill entry, and batch bill query
- Add database migration for `mcp_api_keys` and nginx proxy config for `/mcp`

## Test plan
- [ ] Run `backend/migrations/add_mcp_api_keys.sql` on PostgreSQL
- [ ] Install backend deps (`mcp>=1.10.0`, upgraded `fastapi`/`uvicorn`)
- [ ] Open `/mcp-settings`, generate and revoke MCP API Key
- [ ] Connect Cursor to `https://bill.mitrecx.top/mcp` with the generated key
- [ ] Call `create_bill`, `create_bills_batch`, and `query_bills_batch` tools
- [ ] Verify `/mcp/sse` returns 404 (legacy endpoint removed)


Made with [Cursor](https://cursor.com)