### PR TITLE
feat: unify profile and MCP settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ ssl-certs/*.crt
 
 .vercel/
 .vscode/
+.cursor/mcp.json
 
 .trae/
 docs/项目入门文档.md

--- a/backend/api/mcp_settings.py
+++ b/backend/api/mcp_settings.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
 from api.auth import get_current_user
-from bill_mcp.context import current_mcp_user
+from bill_mcp.context import current_mcp_user_id
 from bill_mcp.server import mcp
 from config.database import SessionLocal, get_db
 from config.settings import settings
@@ -33,7 +33,7 @@ def _extract_api_key(request: Request) -> Optional[str]:
     return request.headers.get("x-mcp-api-key")
 
 
-def _authenticate_request(request: Request) -> User:
+def _authenticate_request(request: Request) -> int:
     raw_key = _extract_api_key(request)
     if not raw_key:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="缺少 MCP API Key")
@@ -43,7 +43,7 @@ def _authenticate_request(request: Request) -> User:
         user = authenticate_mcp_api_key(db, raw_key)
         if not user:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="无效的 MCP API Key")
-        return user
+        return user.id
     finally:
         db.close()
 
@@ -63,13 +63,13 @@ def _get_mcp_asgi_handler():
 
 async def handle_mcp_transport(request: Request):
     """Streamable HTTP MCP 端点（标准路径 /mcp）。"""
-    user = _authenticate_request(request)
-    token = current_mcp_user.set(user)
+    user_id = _authenticate_request(request)
+    token = current_mcp_user_id.set(user_id)
     try:
         handler = _get_mcp_asgi_handler()
         await handler(request.scope, request.receive, request._send)
     finally:
-        current_mcp_user.reset(token)
+        current_mcp_user_id.reset(token)
 
 
 def register_mcp_transport(app) -> None:

--- a/backend/bill_mcp/context.py
+++ b/backend/bill_mcp/context.py
@@ -1,13 +1,11 @@
 from contextvars import ContextVar
 from typing import Optional
 
-from models.user import User
-
-current_mcp_user: ContextVar[Optional[User]] = ContextVar("current_mcp_user", default=None)
+current_mcp_user_id: ContextVar[Optional[int]] = ContextVar("current_mcp_user_id", default=None)
 
 
-def get_current_mcp_user() -> User:
-    user = current_mcp_user.get()
-    if user is None:
+def get_current_mcp_user_id() -> int:
+    user_id = current_mcp_user_id.get()
+    if user_id is None:
         raise RuntimeError("MCP 用户上下文未设置")
-    return user
+    return user_id

--- a/backend/bill_mcp/server.py
+++ b/backend/bill_mcp/server.py
@@ -7,7 +7,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
 from config.database import SessionLocal
-from bill_mcp.context import get_current_mcp_user
+from bill_mcp.context import get_current_mcp_user_id
 from schemas.bills import BillCreate
 from services.bill_service import create_bill_record, create_bills_batch, query_bills
 
@@ -76,7 +76,7 @@ def create_bill(
         remark: 备注（可选）
         source_type: 来源类型，默认 manual
     """
-    user = get_current_mcp_user()
+    user_id = get_current_mcp_user_id()
     db = SessionLocal()
     try:
         payload = _build_bill_create(
@@ -90,7 +90,7 @@ def create_bill(
                 "source_type": source_type,
             }
         )
-        bill = create_bill_record(db, user.id, payload)
+        bill = create_bill_record(db, user_id, payload)
         return json.dumps(
             {"success": True, "message": "创建账单成功", "bill": {"id": bill.id, "amount": bill.amount}},
             ensure_ascii=False,
@@ -109,11 +109,11 @@ def create_bills_batch(bills: List[Dict[str, Any]]) -> str:
     Args:
         bills: 账单列表，每项包含 amount、transaction_time、transaction_type 等字段
     """
-    user = get_current_mcp_user()
+    user_id = get_current_mcp_user_id()
     db = SessionLocal()
     try:
         payloads = [_build_bill_create(item) for item in bills]
-        created = create_bills_batch(db, user.id, payloads)
+        created = create_bills_batch(db, user_id, payloads)
         return json.dumps(
             {
                 "success": True,
@@ -157,7 +157,7 @@ def query_bills_batch(
         min_amount: 最小金额
         max_amount: 最大金额
     """
-    user = get_current_mcp_user()
+    user_id = get_current_mcp_user_id()
     db = SessionLocal()
     try:
         from datetime import date as date_type
@@ -166,7 +166,7 @@ def query_bills_batch(
         parsed_end = date_type.fromisoformat(end_date) if end_date else None
         result = query_bills(
             db,
-            user.id,
+            user_id,
             page=max(page, 1),
             size=min(max(size, 1), 100),
             start_date=parsed_start,

--- a/backend/bill_mcp/server.py
+++ b/backend/bill_mcp/server.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 
 from config.database import SessionLocal
 from bill_mcp.context import get_current_mcp_user
@@ -12,7 +13,20 @@ from services.bill_service import create_bill_record, create_bills_batch, query_
 
 logger = logging.getLogger(__name__)
 
-mcp = FastMCP("Family Bills MCP", stateless_http=True)
+mcp = FastMCP(
+    "Family Bills MCP",
+    stateless_http=True,
+    transport_security=TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=[
+            "127.0.0.1:*",
+            "localhost:*",
+            "[::1]:*",
+            "bill.mitrecx.top",
+            "bill.mitrecx.top:*",
+        ],
+    ),
+)
 
 
 def _parse_datetime(value: str) -> datetime:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,6 @@ import FamilyManagePage from './pages/FamilyManagePage';
 import UsersManagePage from './pages/UsersManagePage';
 import ClassificationRulesPage from './pages/ClassificationRulesPage';
 import PersonalCenterPage from './pages/PersonalCenterPage';
-import McpSettingsPage from './pages/McpSettingsPage';
 import './App.css';
 
 // 受保护的路由组件
@@ -117,8 +116,8 @@ const App: React.FC = () => {
               <Route path="family" element={<FamilyManagePage />} />
               <Route path="classification-rules" element={<ClassificationRulesPage />} />
               <Route path="settings" element={<SettingsPage />} />
-              <Route path="mcp-settings" element={<McpSettingsPage />} />
               <Route path="profile" element={<PersonalCenterPage />} />
+              <Route path="mcp-settings" element={<Navigate to="/profile?tab=mcp" replace />} />
               <Route path="*" element={<Navigate to="/dashboard" replace />} />
             </Route>
           </Routes>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -21,7 +21,6 @@ import {
   MessageOutlined,
   TeamOutlined,
   FilterOutlined,
-  ApiOutlined,
 } from '@ant-design/icons';
 import { useAuthStore } from '../stores/auth';
 import type { MenuProps } from 'antd';
@@ -93,13 +92,8 @@ const Layout: React.FC = () => {
     },
     {
       key: '/profile',
-      icon: <UserOutlined />,
-      label: '个人资料',
-    },
-    {
-      key: '/mcp-settings',
-      icon: <ApiOutlined />,
-      label: 'MCP 设置',
+      icon: <SettingOutlined />,
+      label: '设置',
     },
   ];
 

--- a/frontend/src/components/McpSettingsSection.tsx
+++ b/frontend/src/components/McpSettingsSection.tsx
@@ -14,7 +14,6 @@ import {
   List,
 } from 'antd';
 import {
-  ApiOutlined,
   CopyOutlined,
   KeyOutlined,
   ReloadOutlined,
@@ -23,9 +22,9 @@ import {
 import { McpService } from '../api/services';
 import type { McpApiKeyStatus, McpServerInfo } from '../types/mcp';
 
-const { Paragraph, Text, Title } = Typography;
+const { Paragraph, Text } = Typography;
 
-const McpSettingsPage: React.FC = () => {
+const McpSettingsSection: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [keyStatus, setKeyStatus] = useState<McpApiKeyStatus | null>(null);
   const [serverInfo, setServerInfo] = useState<McpServerInfo | null>(null);
@@ -104,11 +103,7 @@ const McpSettingsPage: React.FC = () => {
     : '';
 
   return (
-    <div>
-      <Title level={4} style={{ marginBottom: 16 }}>
-        <ApiOutlined /> MCP 设置
-      </Title>
-
+    <>
       <Card title="API Key 管理" loading={loading} style={{ marginBottom: 16 }}>
         {keyStatus?.has_key ? (
           <>
@@ -222,8 +217,8 @@ const McpSettingsPage: React.FC = () => {
         />
         <Input.TextArea value={newApiKey || ''} readOnly autoSize={{ minRows: 3 }} style={{ fontFamily: 'monospace' }} />
       </Modal>
-    </div>
+    </>
   );
 };
 
-export default McpSettingsPage;
+export default McpSettingsSection;

--- a/frontend/src/pages/PersonalCenterPage.tsx
+++ b/frontend/src/pages/PersonalCenterPage.tsx
@@ -1,17 +1,21 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Avatar, Typography, Space, Descriptions, Button, Modal, Form, Input, message } from 'antd';
-import { UserOutlined } from '@ant-design/icons';
+import { Card, Avatar, Typography, Space, Descriptions, Button, Modal, Form, Input, message, Tabs } from 'antd';
+import { SettingOutlined, UserOutlined, ApiOutlined } from '@ant-design/icons';
+import { useSearchParams } from 'react-router-dom';
 import { useAuthStore } from '../stores/auth';
 import { UserService } from '../api/services';
+import McpSettingsSection from '../components/McpSettingsSection';
 
 const { Title, Text } = Typography;
 
 const PersonalCenterPage: React.FC = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = searchParams.get('tab') === 'mcp' ? 'mcp' : 'profile';
+
   const { user, loadUser, isAuthenticated, setUser } = useAuthStore();
   const [editOpen, setEditOpen] = useState(false);
   const [form] = Form.useForm();
   const [submitting, setSubmitting] = useState(false);
-  // 新增：密码修改独立弹窗与表单
   const [passwordOpen, setPasswordOpen] = useState(false);
   const [passwordForm] = Form.useForm();
   const [pwdSubmitting, setPwdSubmitting] = useState(false);
@@ -22,7 +26,7 @@ const PersonalCenterPage: React.FC = () => {
         console.error('加载用户信息失败:', err);
       });
     }
-  }, [isAuthenticated]);
+  }, [isAuthenticated, loadUser]);
 
   const openEdit = async () => {
     setEditOpen(true);
@@ -33,8 +37,7 @@ const PersonalCenterPage: React.FC = () => {
         full_name: profile?.full_name || '',
         email: profile?.email || '',
       });
-    } catch (_err: any) {
-      // 静默回退到当前缓存的用户数据进行预填，不显示权限或错误提示
+    } catch {
       form.setFieldsValue({
         full_name: user?.full_name || '',
         email: user?.email || '',
@@ -42,7 +45,6 @@ const PersonalCenterPage: React.FC = () => {
     }
   };
 
-  // 新增：打开修改密码弹窗
   const openChangePassword = () => {
     setPasswordOpen(true);
     passwordForm.resetFields();
@@ -52,9 +54,8 @@ const PersonalCenterPage: React.FC = () => {
   const refreshProfile = async () => {
     try {
       const resp = await UserService.getProfile();
-      const profile = resp.data;
-      return profile;
-    } catch (err) {
+      return resp.data;
+    } catch {
       return null;
     }
   };
@@ -62,20 +63,18 @@ const PersonalCenterPage: React.FC = () => {
   const handleSubmit = async () => {
     try {
       const values = await form.validateFields();
-      const payload: any = {
+      const payload = {
         full_name: values.full_name,
         email: values.email,
       };
       setSubmitting(true);
       const resp = await UserService.updateProfile(payload);
       if (resp.success) {
-        // 立即用后端返回的最新用户数据刷新全局状态，驱动页面即时更新
         if (resp.data) {
           setUser(resp.data);
         }
         message.success('个人资料更新成功');
         setEditOpen(false);
-        // 仍保留一次拉取作为兜底，避免某些字段后端有额外处理
         const p = await refreshProfile();
         if (p) {
           setUser(p);
@@ -100,14 +99,11 @@ const PersonalCenterPage: React.FC = () => {
     }
   };
 
-  // 新增：处理修改密码提交
   const handleChangePassword = async () => {
     try {
       const values = await passwordForm.validateFields();
-      const newPwd = values.new_password;
-      const payload: any = { password: newPwd };
       setPwdSubmitting(true);
-      const resp = await UserService.updateProfile(payload);
+      const resp = await UserService.updateProfile({ password: values.new_password } as any);
       if (resp.success) {
         message.success('密码修改成功');
         setPasswordOpen(false);
@@ -118,16 +114,13 @@ const PersonalCenterPage: React.FC = () => {
       }
     } catch (err: any) {
       if (err?.errorFields) {
-        return; // 表单校验错误
+        return;
       }
-
-      // 直接呈现后端返回的具体错误信息（优先 detail/message），不再使用统一的“操作被拒绝”提示
       const data = err?.response?.data;
       let backendMsg: string | undefined;
 
       if (data) {
         if (Array.isArray(data.detail)) {
-          // FastAPI/Pydantic 422 错误数组：组合所有详细信息
           backendMsg = data.detail
             .map((d: any) => {
               const loc = Array.isArray(d?.loc) ? d.loc.join('.') : d?.loc;
@@ -145,40 +138,76 @@ const PersonalCenterPage: React.FC = () => {
         }
       }
 
-      const finalMsg = backendMsg || err?.message || '密码修改失败，请稍后重试';
-      message.error(finalMsg);
+      message.error(backendMsg || err?.message || '密码修改失败，请稍后重试');
     } finally {
       setPwdSubmitting(false);
     }
   };
 
+  const profileContent = (
+    <Card>
+      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+        <Space align="center" size="large" style={{ width: '100%', justifyContent: 'space-between' }}>
+          <Space align="center" size="large">
+            <Avatar size={96} icon={<UserOutlined />} style={{ backgroundColor: '#1890ff' }}>
+              {user?.full_name?.[0] || user?.username?.[0] || 'U'}
+            </Avatar>
+            <div>
+              <Title level={3} style={{ marginBottom: 4 }}>{user?.full_name || user?.username || '用户'}</Title>
+              <Text type="secondary">@{user?.username}</Text>
+            </div>
+          </Space>
+          <Space>
+            <Button onClick={openChangePassword}>修改密码</Button>
+            <Button type="primary" onClick={openEdit}>编辑资料</Button>
+          </Space>
+        </Space>
+
+        <Descriptions column={1} bordered size="middle">
+          <Descriptions.Item label="用户名">{user?.username || '-'}</Descriptions.Item>
+          <Descriptions.Item label="邮箱">{user?.email || '-'}</Descriptions.Item>
+          <Descriptions.Item label="姓名">{user?.full_name || '-'}</Descriptions.Item>
+        </Descriptions>
+      </Space>
+    </Card>
+  );
+
   return (
     <div>
-      <Card>
-        <Space direction="vertical" size="large" style={{ width: '100%' }}>
-          <Space align="center" size="large" style={{ width: '100%', justifyContent: 'space-between' }}>
-            <Space align="center" size="large">
-              <Avatar size={96} icon={<UserOutlined />} style={{ backgroundColor: '#1890ff' }}>
-                {user?.full_name?.[0] || user?.username?.[0] || 'U'}
-              </Avatar>
-              <div>
-                <Title level={3} style={{ marginBottom: 4 }}>{user?.full_name || user?.username || '用户'}</Title>
-                <Text type="secondary">@{user?.username}</Text>
-              </div>
-            </Space>
-            <Space>
-              <Button onClick={openChangePassword}>修改密码</Button>
-              <Button type="primary" onClick={openEdit}>编辑资料</Button>
-            </Space>
-          </Space>
+      <Title level={4} style={{ marginBottom: 16 }}>
+        <SettingOutlined /> 设置
+      </Title>
 
-          <Descriptions column={1} bordered size="middle">
-            <Descriptions.Item label="用户名">{user?.username || '-'}</Descriptions.Item>
-            <Descriptions.Item label="邮箱">{user?.email || '-'}</Descriptions.Item>
-            <Descriptions.Item label="姓名">{user?.full_name || '-'}</Descriptions.Item>
-          </Descriptions>
-        </Space>
-      </Card>
+      <Tabs
+        activeKey={activeTab}
+        onChange={(key) => {
+          if (key === 'profile') {
+            setSearchParams({});
+          } else {
+            setSearchParams({ tab: key });
+          }
+        }}
+        items={[
+          {
+            key: 'profile',
+            label: (
+              <span>
+                <UserOutlined /> 个人资料
+              </span>
+            ),
+            children: profileContent,
+          },
+          {
+            key: 'mcp',
+            label: (
+              <span>
+                <ApiOutlined /> MCP
+              </span>
+            ),
+            children: <McpSettingsSection />,
+          },
+        ]}
+      />
 
       <Modal
         title="编辑个人资料"
@@ -194,16 +223,12 @@ const PersonalCenterPage: React.FC = () => {
           <Form.Item label="姓名" name="full_name">
             <Input placeholder="请输入姓名" allowClear />
           </Form.Item>
-          <Form.Item label="邮箱" name="email" rules={[
-            { type: 'email', message: '邮箱格式不正确' },
-          ]}>
+          <Form.Item label="邮箱" name="email" rules={[{ type: 'email', message: '邮箱格式不正确' }]}>
             <Input placeholder="请输入邮箱" allowClear />
           </Form.Item>
-          {/* 注意：已移除所有与密码相关的输入框 */}
         </Form>
       </Modal>
 
-      {/* 新增：修改密码独立弹窗 */}
       <Modal
         title="修改密码"
         open={passwordOpen}
@@ -221,7 +246,7 @@ const PersonalCenterPage: React.FC = () => {
           ]}>
             <Input.Password placeholder="请输入新密码" allowClear />
           </Form.Item>
-          <Form.Item label="确认密码" name="confirm_password" dependencies={["new_password"]} rules={[
+          <Form.Item label="确认密码" name="confirm_password" dependencies={['new_password']} rules={[
             { required: true, message: '请再次输入新密码' },
             ({ getFieldValue }) => ({
               validator(_, value) {


### PR DESCRIPTION
## Summary
- Merge personal profile and MCP configuration into a single **设置** page at `/profile` with tabs
- Redirect legacy `/mcp-settings` to `/profile?tab=mcp`
- Allow `bill.mitrecx.top` in MCP Streamable HTTP Host validation for HTTPS access via nginx
- Gitignore project-local `.cursor/mcp.json` so API keys are not committed

## Test plan
- [ ] Open `/profile` and verify **个人资料** and **MCP** tabs work
- [ ] Confirm `/mcp-settings` redirects to `/profile?tab=mcp`
- [ ] Verify sidebar shows a single **设置** menu item
- [ ] Test `POST https://bill.mitrecx.top/mcp` with a valid API key returns initialize response (not `Invalid Host header`)


Made with [Cursor](https://cursor.com)