### PR TITLE
feat(mcp): add bill update and delete tools

### DIFF
--- a/backend/api/mcp_settings.py
+++ b/backend/api/mcp_settings.py
@@ -145,7 +145,15 @@ async def get_mcp_server_info(
         data=McpServerInfoResponse(
             server_name="Family Bills MCP",
             mcp_url=mcp_url,
-            tools=["create_bill", "create_bills_batch", "query_bills_batch"],
+            tools=[
+                "create_bill",
+                "create_bills_batch",
+                "query_bills_batch",
+                "update_bill",
+                "update_bills_batch",
+                "delete_bill",
+                "delete_bills_batch",
+            ],
             cursor_config_example={
                 "mcpServers": {
                     "family-bills": {

--- a/backend/bill_mcp/server.py
+++ b/backend/bill_mcp/server.py
@@ -8,8 +8,16 @@ from mcp.server.transport_security import TransportSecuritySettings
 
 from config.database import SessionLocal
 from bill_mcp.context import get_current_mcp_user_id
-from schemas.bills import BillCreate
-from services.bill_service import create_bill_record, create_bills_batch, query_bills
+from schemas.bills import BillCreate, BillUpdate
+from services.bill_service import (
+    create_bill_record,
+    create_bills_batch,
+    delete_bill_record,
+    delete_bills_batch as delete_bills_batch_records,
+    query_bills,
+    update_bill_record,
+    update_bills_batch as update_bills_batch_records,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -181,6 +189,118 @@ def query_bills_batch(
         return json.dumps({"success": True, "data": result}, ensure_ascii=False, default=str)
     except Exception as exc:
         logger.error("MCP query_bills_batch failed: %s", exc)
+        return json.dumps({"success": False, "message": str(exc)}, ensure_ascii=False)
+    finally:
+        db.close()
+
+
+@mcp.tool()
+def delete_bill(bill_id: int) -> str:
+    """删除单条账单（仅可删除当前用户自己的账单）。
+
+    Args:
+        bill_id: 账单 ID
+    """
+    user_id = get_current_mcp_user_id()
+    db = SessionLocal()
+    try:
+        delete_bill_record(db, user_id, bill_id)
+        return json.dumps({"success": True, "message": "账单删除成功", "bill_id": bill_id}, ensure_ascii=False)
+    except Exception as exc:
+        logger.error("MCP delete_bill failed: %s", exc)
+        return json.dumps({"success": False, "message": str(exc)}, ensure_ascii=False)
+    finally:
+        db.close()
+
+
+@mcp.tool()
+def delete_bills_batch(bill_ids: List[int]) -> str:
+    """批量删除账单（仅可删除当前用户自己的账单）。
+
+    Args:
+        bill_ids: 要删除的账单 ID 列表
+    """
+    user_id = get_current_mcp_user_id()
+    db = SessionLocal()
+    try:
+        result = delete_bills_batch_records(db, user_id, bill_ids)
+        return json.dumps(
+            {
+                "success": len(result["failed"]) == 0,
+                "message": f"成功删除 {len(result['deleted_ids'])} 条账单",
+                **result,
+            },
+            ensure_ascii=False,
+        )
+    except Exception as exc:
+        logger.error("MCP delete_bills_batch failed: %s", exc)
+        return json.dumps({"success": False, "message": str(exc)}, ensure_ascii=False)
+    finally:
+        db.close()
+
+
+@mcp.tool()
+def update_bill(
+    bill_id: int,
+    amount: Optional[float] = None,
+    transaction_type: Optional[str] = None,
+    transaction_desc: Optional[str] = None,
+    category_id: Optional[int] = None,
+    remark: Optional[str] = None,
+) -> str:
+    """修改单条账单（仅可修改当前用户自己的账单，只更新传入的字段）。
+
+    Args:
+        bill_id: 账单 ID
+        amount: 金额（可选）
+        transaction_type: 交易类型 income/expense/transfer（可选）
+        transaction_desc: 交易描述（可选）
+        category_id: 分类 ID（可选）
+        remark: 备注（可选）
+    """
+    user_id = get_current_mcp_user_id()
+    db = SessionLocal()
+    try:
+        payload = BillUpdate(
+            amount=amount,
+            transaction_type=transaction_type,
+            transaction_desc=transaction_desc,
+            category_id=category_id,
+            remark=remark,
+        )
+        bill = update_bill_record(db, user_id, bill_id, payload)
+        return json.dumps(
+            {"success": True, "message": "更新账单成功", "bill": {"id": bill.id, "amount": bill.amount}},
+            ensure_ascii=False,
+        )
+    except Exception as exc:
+        logger.error("MCP update_bill failed: %s", exc)
+        return json.dumps({"success": False, "message": str(exc)}, ensure_ascii=False)
+    finally:
+        db.close()
+
+
+@mcp.tool()
+def update_bills_batch(bills: List[Dict[str, Any]]) -> str:
+    """批量修改账单（仅可修改当前用户自己的账单）。
+
+    Args:
+        bills: 账单更新列表，每项需包含 bill_id，以及要更新的字段
+    """
+    user_id = get_current_mcp_user_id()
+    db = SessionLocal()
+    try:
+        result = update_bills_batch_records(db, user_id, bills)
+        return json.dumps(
+            {
+                "success": len(result["failed"]) == 0,
+                "message": f"成功更新 {len(result['updated'])} 条账单",
+                **result,
+            },
+            ensure_ascii=False,
+        )
+    except Exception as exc:
+        logger.error("MCP update_bills_batch failed: %s", exc)
         return json.dumps({"success": False, "message": str(exc)}, ensure_ascii=False)
     finally:
         db.close()

--- a/backend/services/bill_service.py
+++ b/backend/services/bill_service.py
@@ -6,7 +6,7 @@ from sqlalchemy import desc
 
 from models.bill import Bill, BillCategory
 from models.family import FamilyMember
-from schemas.bills import BillCreate, BillResponse
+from schemas.bills import BillCreate, BillResponse, BillUpdate
 
 
 TRANSACTION_TYPE_TO_CN = {
@@ -148,3 +148,88 @@ def query_bills(
         "size": size,
         "items": [BillResponse.from_bill(bill).model_dump(mode="json") for bill in items],
     }
+
+
+def delete_bill_record(db: Session, user_id: int, bill_id: int) -> None:
+    bill = db.query(Bill).filter(Bill.id == bill_id, Bill.user_id == user_id).first()
+    if not bill:
+        raise ValueError("无法删除他人的账单数据或账单不存在")
+    db.delete(bill)
+    db.commit()
+
+
+def delete_bills_batch(db: Session, user_id: int, bill_ids: List[int]) -> Dict[str, Any]:
+    deleted_ids: List[int] = []
+    failed: List[Dict[str, Any]] = []
+
+    for bill_id in bill_ids:
+        bill = db.query(Bill).filter(Bill.id == bill_id, Bill.user_id == user_id).first()
+        if not bill:
+            failed.append({"bill_id": bill_id, "reason": "无法删除他人的账单数据或账单不存在"})
+            continue
+        db.delete(bill)
+        deleted_ids.append(bill_id)
+
+    if deleted_ids:
+        db.commit()
+    return {"deleted_ids": deleted_ids, "failed": failed}
+
+
+def _apply_bill_update(bill: Bill, payload: BillUpdate) -> None:
+    if payload.amount is not None:
+        bill.amount = payload.amount
+    if payload.transaction_type is not None:
+        bill.transaction_type = TRANSACTION_TYPE_TO_CN.get(payload.transaction_type, payload.transaction_type)
+    if payload.transaction_desc is not None:
+        bill.transaction_desc = payload.transaction_desc
+    if payload.category_id is not None:
+        bill.category_id = payload.category_id
+    if payload.remark is not None:
+        bill.remark = payload.remark
+
+
+def update_bill_record(db: Session, user_id: int, bill_id: int, payload: BillUpdate) -> Bill:
+    bill = db.query(Bill).filter(Bill.id == bill_id, Bill.user_id == user_id).first()
+    if not bill:
+        raise ValueError("无法修改他人的账单数据或账单不存在")
+    if payload.category_id is not None:
+        _validate_category(db, payload.category_id)
+    _apply_bill_update(bill, payload)
+    db.commit()
+    db.refresh(bill)
+    return bill
+
+
+def update_bills_batch(db: Session, user_id: int, items: List[Dict[str, Any]]) -> Dict[str, Any]:
+    updated: List[Dict[str, Any]] = []
+    failed: List[Dict[str, Any]] = []
+
+    for item in items:
+        bill_id = item.get("bill_id")
+        if not bill_id:
+            failed.append({"bill_id": None, "reason": "缺少 bill_id"})
+            continue
+
+        bill = db.query(Bill).filter(Bill.id == bill_id, Bill.user_id == user_id).first()
+        if not bill:
+            failed.append({"bill_id": bill_id, "reason": "无法修改他人的账单数据或账单不存在"})
+            continue
+
+        try:
+            payload = BillUpdate(
+                amount=item.get("amount"),
+                transaction_type=item.get("transaction_type"),
+                transaction_desc=item.get("transaction_desc"),
+                category_id=item.get("category_id"),
+                remark=item.get("remark"),
+            )
+            if payload.category_id is not None:
+                _validate_category(db, payload.category_id)
+            _apply_bill_update(bill, payload)
+            updated.append({"bill_id": bill_id})
+        except ValueError as exc:
+            failed.append({"bill_id": bill_id, "reason": str(exc)})
+
+    if updated:
+        db.commit()
+    return {"updated": updated, "failed": failed}

--- a/frontend/src/components/McpSettingsSection.tsx
+++ b/frontend/src/components/McpSettingsSection.tsx
@@ -165,6 +165,10 @@ const McpSettingsSection: React.FC = () => {
                 { name: 'create_bill', desc: '单条账单录入' },
                 { name: 'create_bills_batch', desc: '批量账单录入' },
                 { name: 'query_bills_batch', desc: '批量账单查询（支持多条件筛选）' },
+                { name: 'update_bill', desc: '单条账单修改（仅限本人账单）' },
+                { name: 'update_bills_batch', desc: '批量账单修改（仅限本人账单）' },
+                { name: 'delete_bill', desc: '单条账单删除（仅限本人账单）' },
+                { name: 'delete_bills_batch', desc: '批量账单删除（仅限本人账单）' },
               ]}
               renderItem={(item) => (
                 <List.Item>


### PR DESCRIPTION
## Summary
- Add MCP tools to update and delete bills: `update_bill`, `update_bills_batch`, `delete_bill`, `delete_bills_batch`
- Reuse shared service-layer logic with REST API permission rules (own bills only)
- Update MCP settings UI tool list

## Test plan
- [ ] Call `update_bill` on own bill and verify fields change
- [ ] Call `delete_bill` on own bill and verify removal
- [ ] Confirm updating/deleting another user's bill returns an error
- [ ] Verify batch tools report partial failures correctly


Made with [Cursor](https://cursor.com)